### PR TITLE
Fixing hanging docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 backup/*
 extract/*
+output/*


### PR DESCRIPTION
Due to lacking entries in the .dockerignore file the docker build context hangs when large files are in the output folder

this closes #1 